### PR TITLE
Retry update response

### DIFF
--- a/tests/test_weather_underground_conditions_block.py
+++ b/tests/test_weather_underground_conditions_block.py
@@ -42,6 +42,7 @@ class TestWeatherUndergroundConditions(NIOBlockTestCase):
                              state,
                              city)
                          )
+        self.assertDictEqual(self.last_signal_notified().to_dict(), mock_json.return_value["current_observation"])
         blk.stop()
 
     @patch("requests.get")

--- a/weather_underground_base.py
+++ b/weather_underground_base.py
@@ -38,7 +38,8 @@ class WeatherUndergroundBase(Retry, Block):
                 self.get_weather_from_city_state,
                 self.state(signal),
                 self.city(signal))
-            weather_signals.append(Signal(response.json()))
+            weather_signals.append(Signal(response.json()['current_observation']))
+            self.logger.debug("Weather Signal: {}".format(response.json()['current_observation']))
 
         self.notify_signals(weather_signals)
 

--- a/weather_underground_base.py
+++ b/weather_underground_base.py
@@ -38,8 +38,12 @@ class WeatherUndergroundBase(Retry, Block):
                 self.get_weather_from_city_state,
                 self.state(signal),
                 self.city(signal))
-            weather_signals.append(Signal(response.json()['current_observation']))
-            self.logger.debug("Weather Signal: {}".format(response.json()['current_observation']))
+            try:
+                weather_signals.append(Signal(response.json()['current_observation']))
+                self.logger.debug("Weather Signal: {}".format(response.json()['current_observation']))
+            except:
+                weather_signals.append(Signal(response.json()['forecast']))
+                self.logger.debug("Weather Signal: {}".format(response.json()['forecast']))
 
         self.notify_signals(weather_signals)
 


### PR DESCRIPTION
Un-nesting returned signals from either "current_observation" or "forecast" objects. This fixes issue #26.