### PR TITLE
Refactoring condition specific signals

### DIFF
--- a/weather_underground_base.py
+++ b/weather_underground_base.py
@@ -31,6 +31,9 @@ class WeatherUndergroundBase(Retry, Block):
         super().__init__()
         self._api_endpoint = None
 
+    def get_signal_from_response(self, resp):
+        return Signal(resp.json())
+
     def process_signals(self, signals):
         weather_signals = []
         for signal in signals:
@@ -38,12 +41,8 @@ class WeatherUndergroundBase(Retry, Block):
                 self.get_weather_from_city_state,
                 self.state(signal),
                 self.city(signal))
-            try:
-                weather_signals.append(Signal(response.json()['current_observation']))
-                self.logger.debug("Weather Signal: {}".format(response.json()['current_observation']))
-            except:
-                weather_signals.append(Signal(response.json()['forecast']))
-                self.logger.debug("Weather Signal: {}".format(response.json()['forecast']))
+
+            weather_signals.append(self.get_signal_from_response(response))
 
         self.notify_signals(weather_signals)
 

--- a/weather_underground_conditions_block.py
+++ b/weather_underground_conditions_block.py
@@ -17,7 +17,7 @@ class WeatherUndergroundConditions(WeatherUndergroundBase):
 
     """
 
-    version = VersionProperty(version='1.0.0')
+    version = VersionProperty(version='2.0.0')
 
     def __init__(self):
         super().__init__()

--- a/weather_underground_conditions_block.py
+++ b/weather_underground_conditions_block.py
@@ -1,6 +1,7 @@
 from nio.util.discovery import discoverable
 from nio.properties.version import VersionProperty
 from .weather_underground_base import WeatherUndergroundBase
+from nio.signal.base import Signal
 
 
 @discoverable
@@ -21,3 +22,6 @@ class WeatherUndergroundConditions(WeatherUndergroundBase):
     def __init__(self):
         super().__init__()
         self._api_endpoint = 'conditions'
+
+    def get_signal_from_response(self, resp):
+        return Signal(resp.json().get('current_observation'))

--- a/weather_underground_forecast10day_block.py
+++ b/weather_underground_forecast10day_block.py
@@ -1,6 +1,7 @@
 from nio.util.discovery import discoverable
 from nio.properties.version import VersionProperty
 from .weather_underground_base import WeatherUndergroundBase
+from nio.signal.base import Signal
 
 
 @discoverable
@@ -21,3 +22,6 @@ class WeatherUndergroundForecast10Day(WeatherUndergroundBase):
     def __init__(self):
         super().__init__()
         self._api_endpoint = 'forecast10day'
+
+    def get_signal_from_response(self, resp):
+        return Signal(resp.json().get('forecast'))

--- a/weather_underground_forecast10day_block.py
+++ b/weather_underground_forecast10day_block.py
@@ -17,7 +17,7 @@ class WeatherUndergroundForecast10Day(WeatherUndergroundBase):
 
     """
 
-    version = VersionProperty(version='1.0.0')
+    version = VersionProperty(version='2.0.0')
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
This is the refactored solution for issue #28. The base block now calls a function to append the correct signal which will come from either the conditions or forecast10day block. All local tests pass with this fix. Please let me know if I missed something here. 